### PR TITLE
Fixed a bug where max() was used and overwritten

### DIFF
--- a/masksembles/common.py
+++ b/masksembles/common.py
@@ -84,7 +84,7 @@ def generation_wrapper(c: int, n: int, scale: float) -> np.ndarray:
     # Fix the last part by using binary search 
     max_iter = 1000
 
-    min = max(scale * 0.8, 1.0)
+    min = np.max([scale * 0.8, 1.0])
     max = scale * 1.2
 
     for _ in range(max_iter):


### PR DESCRIPTION
I tried to run the code for myself by just importing generation_wrapper() directly. With this I got the following error: "UnboundLocalError: local variable 'max' referenced before assignment".

I fixed it using the code provided. I just thought I would share the fix and you can implement it if you want :)